### PR TITLE
The utf8 codification of serialized job is not a Eixo::Queue::Job responsability

### DIFF
--- a/lib/Eixo/Queue/Job.pm
+++ b/lib/Eixo/Queue/Job.pm
@@ -100,7 +100,7 @@ sub finished{
 sub serialize{
     my ($self) = @_;
 
-    JSON->new->convert_blessed->utf8(0)->encode( $self )
+    JSON->new->convert_blessed->encode( $self )
 }
 
 sub unserialize{
@@ -110,7 +110,7 @@ sub unserialize{
         $package = ref($package);
     }
 
-    bless(JSON->new->utf8->decode($data), $package);
+    bless(JSON->new->decode($data), $package);
 }
 
 sub setArg{


### PR DESCRIPTION
If the job is going to be output to a filehandle, stdout, net you could obtain similar behaviour with
- PERL_UNICODE=SDAL or
- perl -CSDAL
